### PR TITLE
Fix a benign race detected by the race detector.

### DIFF
--- a/btcec.go
+++ b/btcec.go
@@ -646,7 +646,7 @@ func (curve *KoblitzCurve) ScalarBaseMult(k []byte) (*big.Int, *big.Int) {
 	// Each "digit" in the 8-bit window can be looked up using bytePoints
 	// and added together.
 	for i, byteVal := range k {
-		point := &curve.bytePoints[diff+i][byteVal]
+		point := curve.bytePoints[diff+i][byteVal]
 		curve.addJacobian(qx, qy, qz, &point[0], &point[1], &point[2], qx, qy, qz)
 	}
 	return curve.fieldJacobianToBigAffine(qx, qy, qz)


### PR DESCRIPTION
The addition of the pre-computed values for the ScalarBaseMult optimizations added a benign race condition since a pointer to each pre-computed Jacobian point was being used in the call to addJacobian instead of a local stack copy.

This resulted in the code which normalizes the field values to check for further optimization conditions such as equal Z values to race against the IsZero checks when multiple goroutines were performing EC operations since
they were all operating on the same point in memory.

In practice this was benign since the value was being replaced with the same thing and thus it was the same before and after the race, but it's never a good idea to have races.